### PR TITLE
fix python docs empty table

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc.mustache
@@ -42,6 +42,7 @@ Method | HTTP request | Description
 
 ### Parameters
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
+
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
 {{#requiredParams}}{{^defaultValue}} **{{paramName}}** | {{^baseType}}**{{dataType}}**{{/baseType}}{{#baseType}}[**{{dataType}}**]({{baseType}}.md){{/baseType}}| {{description}} |

--- a/modules/openapi-generator/src/main/resources/python/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_doc.mustache
@@ -4,6 +4,7 @@
 {{/description}}
 
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 {{#isEnum}}


### PR DESCRIPTION
Needs to keep whitespace after title to make the doc render works for empty tables.