### PR TITLE
Fix error with quote URL path

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -516,7 +516,7 @@ class ApiClient(object):
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend((k, quote(str(value))) for value in v)
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -553,7 +553,7 @@ class ApiClient(object):
             if k in collection_formats:
                 collection_format = collection_formats[k]
                 if collection_format == 'multi':
-                    new_params.extend((k, value) for value in v)
+                    new_params.extend((k, quote(str(value))) for value in v)
                 else:
                     if collection_format == 'ssv':
                         delimiter = ' '

--- a/modules/openapi-generator/src/main/resources/python/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc.mustache
@@ -62,6 +62,7 @@ Name | Type | Description  | Notes
 
 {{#responses.0}}
 ### HTTP response details
+
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 {{#responses}}


### PR DESCRIPTION
Filenames which contain path are now properly encoded in the URL. 